### PR TITLE
Fix `docs.rs` configuration by enabling `cfg_doc`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # Ironbeam
 //!
 //! A **data processing framework** for Rust inspired by Apache Beam and Google Cloud Dataflow.


### PR DESCRIPTION
Attempts to fix `docs.rs` build by enabling `cfg_doc` feature project-wide.