### PR TITLE
chore: Change version to make Docs.rs rebuild with proper flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironbeam"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "A batch processing clone of Apache Beam in Rust."


### PR DESCRIPTION
Update the version of the package to force a full rebuild on docs.rs