### PR TITLE
feat(helpers): add distinct_by for deduplication by key projection

### DIFF
--- a/src/helpers/distinct.rs
+++ b/src/helpers/distinct.rs
@@ -2,6 +2,7 @@
 //!
 //! # Overview
 //! - [`PCollection::distinct`](PCollection::distinct) - Remove duplicates globally (exact)
+//! - [`PCollection::distinct_by`](PCollection::distinct_by) - Remove duplicates by a computed projection
 //! - [`PCollection::distinct_per_key`](crate::PCollection::distinct_per_key) - Remove duplicate values per key (exact)
 //! - [`PCollection::distinct_count_globally`] - Exact count of distinct elements (global)
 //! - [`PCollection::distinct_count_per_key`] - Exact count of distinct values per key
@@ -81,6 +82,56 @@ impl<T: RFBound + Eq + Hash> PCollection<T> {
     #[must_use]
     pub fn approx_distinct_count(self, k: usize) -> PCollection<f64> {
         self.combine_globally(KMVApproxDistinctCount::<T>::new(k), None)
+    }
+}
+
+impl<T: RFBound> PCollection<T> {
+    /// Deduplicate elements by a computed projection, keeping one arbitrary element per
+    /// distinct key value.
+    ///
+    /// This differs from [`distinct`](Self::distinct), which requires `T: Eq + Hash` and
+    /// deduplicates the element itself. `distinct_by` lets you project to any hashable key
+    /// and retains one full element for each unique projected value.
+    ///
+    /// The element retained per key is **arbitrary** (determined by processing order).
+    /// If a specific element must be selected, sort or filter before calling this method.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// use ironbeam::*;
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// struct Event { user_id: u32, payload: String }
+    ///
+    /// # fn main() -> Result<()> {
+    /// let p = Pipeline::default();
+    /// let events = from_vec(&p, vec![
+    ///     Event { user_id: 1, payload: "first".into() },
+    ///     Event { user_id: 1, payload: "second".into() },
+    ///     Event { user_id: 2, payload: "only".into() },
+    /// ]);
+    ///
+    /// // Keep one event per user_id
+    /// let one_per_user = events.distinct_by(|e| e.user_id);
+    /// let mut results = one_per_user.collect_seq()?;
+    /// results.sort_by_key(|e| e.user_id);
+    /// assert_eq!(results.len(), 2);
+    /// assert_eq!(results[0].user_id, 1);
+    /// assert_eq!(results[1].user_id, 2);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn distinct_by<K, F>(self, key_fn: F) -> Self
+    where
+        K: RFBound + Eq + Hash,
+        F: 'static + Send + Sync + Fn(&T) -> K,
+    {
+        self.key_by(key_fn)
+            .group_by_key()
+            .flat_map(|kv: &(K, Vec<T>)| kv.1.iter().take(1).cloned().collect::<Vec<_>>())
     }
 }
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -60,6 +60,7 @@
 //! ### Distinct Operations
 //! - [`distinct`] - Remove duplicate elements and count distinct values
 //!   - [`PCollection::distinct`](crate::PCollection::distinct)
+//!   - [`PCollection::distinct_by`](crate::PCollection::distinct_by)
 //!   - [`PCollection::distinct_per_key`](crate::PCollection::distinct_per_key)
 //!   - [`PCollection::distinct_count_globally`](crate::PCollection::distinct_count_globally)
 //!   - [`PCollection::distinct_count_per_key`](crate::PCollection::distinct_count_per_key)

--- a/src/helpers/partition.rs
+++ b/src/helpers/partition.rs
@@ -13,7 +13,7 @@
 //! 1. Define an enum with variants for each output type
 //! 2. Use [`flat_map`](crate::PCollection::flat_map) to produce the enum
 //! 3. Use [`filter_map`](crate::PCollection::filter_map) to extract each variant
-//! 4. Or use the [`partition!`] macro for convenience
+//! 4. Or use the [`partition!`](macro@crate::partition) macro for convenience
 //!
 //! This approach is:
 //! - **Type-safe**: Enum variants are checked at compile time
@@ -88,7 +88,7 @@
 //!
 //! ### Using the `partition!` Macro (Most Convenient)
 //!
-//! The [`partition!`] macro reduces boilerplate by automatically generating the
+//! The [`partition!`](macro@crate::partition) macro reduces boilerplate by automatically generating the
 //! `filter_map` calls for each variant:
 //!
 //! ```no_run

--- a/tests/helpers/distinct.rs
+++ b/tests/helpers/distinct.rs
@@ -1,0 +1,141 @@
+//! Tests for `distinct_by`: deduplication by a computed key projection.
+
+use anyhow::Result;
+use ironbeam::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Event {
+    user_id: u32,
+    payload: String,
+}
+
+// ─────────────────────────────── distinct_by ─────────────────────────────────
+
+#[test]
+fn distinct_by_removes_duplicates_by_field() -> Result<()> {
+    let p = Pipeline::default();
+    let events = from_vec(
+        &p,
+        vec![
+            Event { user_id: 1, payload: "first".into() },
+            Event { user_id: 1, payload: "second".into() },
+            Event { user_id: 2, payload: "only".into() },
+        ],
+    );
+    let mut result = events.distinct_by(|e| e.user_id).collect_seq()?;
+    result.sort();
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].user_id, 1);
+    assert_eq!(result[1].user_id, 2);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_empty_collection() -> Result<()> {
+    let p = Pipeline::default();
+    let result = from_vec::<Event>(&p, vec![])
+        .distinct_by(|e| e.user_id)
+        .collect_seq()?;
+    assert!(result.is_empty());
+    Ok(())
+}
+
+#[test]
+fn distinct_by_single_element() -> Result<()> {
+    let p = Pipeline::default();
+    let events = from_vec(&p, vec![Event { user_id: 42, payload: "hello".into() }]);
+    let result = events.distinct_by(|e| e.user_id).collect_seq()?;
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].user_id, 42);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_all_same_key_returns_one() -> Result<()> {
+    let p = Pipeline::default();
+    let events = from_vec(
+        &p,
+        vec![
+            Event { user_id: 7, payload: "a".into() },
+            Event { user_id: 7, payload: "b".into() },
+            Event { user_id: 7, payload: "c".into() },
+        ],
+    );
+    let result = events.distinct_by(|e| e.user_id).collect_seq()?;
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].user_id, 7);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_all_unique_keys_passes_all_through() -> Result<()> {
+    let p = Pipeline::default();
+    let events = from_vec(
+        &p,
+        vec![
+            Event { user_id: 1, payload: "a".into() },
+            Event { user_id: 2, payload: "b".into() },
+            Event { user_id: 3, payload: "c".into() },
+        ],
+    );
+    let mut result = events.distinct_by(|e| e.user_id).collect_seq()?;
+    result.sort_by_key(|e| e.user_id);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0].user_id, 1);
+    assert_eq!(result[1].user_id, 2);
+    assert_eq!(result[2].user_id, 3);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_string_key_projection() -> Result<()> {
+    let p = Pipeline::default();
+    // Deduplicate by first character of a string
+    let words = from_vec(&p, vec!["apple", "avocado", "banana", "blueberry", "cherry"]);
+    let result_count = words
+        .distinct_by(|w: &&str| w.chars().next().unwrap())
+        .collect_seq()?
+        .len();
+    // 'a', 'b', 'c' → 3 distinct groups
+    assert_eq!(result_count, 3);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_computed_projection() -> Result<()> {
+    let p = Pipeline::default();
+    // Deduplicate integers by their value modulo 3
+    let nums = from_vec(&p, vec![0u32, 3, 6, 1, 4, 7, 2, 5, 8]);
+    let result_count = nums.distinct_by(|n| n % 3).collect_seq()?.len();
+    // mod-3 buckets: 0, 1, 2 → 3 groups
+    assert_eq!(result_count, 3);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_large_collection() -> Result<()> {
+    let p = Pipeline::default();
+    // 1000 elements, 10 distinct keys (0..10 cycling)
+    let data: Vec<u32> = (0..1000).collect();
+    let result_count = from_vec(&p, data).distinct_by(|n| n % 10).collect_seq()?.len();
+    assert_eq!(result_count, 10);
+    Ok(())
+}
+
+#[test]
+fn distinct_by_retains_full_element_not_just_key() -> Result<()> {
+    let p = Pipeline::default();
+    let events = from_vec(
+        &p,
+        vec![
+            Event { user_id: 5, payload: "payload_a".into() },
+            Event { user_id: 5, payload: "payload_b".into() },
+        ],
+    );
+    let result = events.distinct_by(|e| e.user_id).collect_seq()?;
+    assert_eq!(result.len(), 1);
+    // The result is a full Event, not just the user_id
+    assert_eq!(result[0].user_id, 5);
+    assert!(!result[0].payload.is_empty());
+    Ok(())
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -2,6 +2,7 @@
 mod basic;
 mod batching;
 mod cloud;
+mod distinct;
 mod joins;
 mod parquet;
 mod side_input;


### PR DESCRIPTION
## Summary

- Adds `PCollection::distinct_by(key_fn)` to `src/helpers/distinct.rs` — deduplicates elements by a computed key projection, keeping one arbitrary element per distinct key value. This complements the existing `distinct()` (which requires `T: Eq + Hash`) by allowing deduplication on any projected hashable field without requiring the element type itself to be hashable.
- Updates the `distinct` section of the `src/helpers/mod.rs` doc index to include `distinct_by`.
- Fixes two unresolved rustdoc links in `src/helpers/partition.rs` for the `partition!` macro (changed from `[`partition!`]` to `[`partition!`](macro@crate::partition)` to disambiguate from the `partition` module).
- Adds 9 tests in `tests/helpers/distinct.rs` covering: struct field projection, empty collection, single element, all-same-key, all-unique-keys, string key, computed projection, large collection, and full-element retention.

## Test plan

- [x] `cargo clippy -- -D warnings -W clippy::pedantic -W clippy::nursery` passes with no warnings or errors
- [x] `cargo doc` produces no warnings
- [x] `cargo test helpers::distinct` — all 9 new tests pass