### PR TITLE
fix(deps): upgrade sha2 from 0.10 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,11 +314,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -428,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,9 +461,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -510,12 +516,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -541,11 +546,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -614,16 +620,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -702,6 +698,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1257,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1"
 ordered-float = "5"
 glob = "0.3"
 postcard = { version = "1", features = ["alloc"], optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.11", optional = true }
 regex = "1.12.2"
 paste = "1"
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -391,8 +391,11 @@ pub fn compute_checksum(data: &[u8]) -> String {
     hasher
         .finalize()
         .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect()
+        .fold(String::new(), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
 }
 
 /// Generate a stable pipeline ID from the pipeline structure.
@@ -400,11 +403,14 @@ pub fn compute_checksum(data: &[u8]) -> String {
 pub(crate) fn generate_pipeline_id(pipeline_hash: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(pipeline_hash.as_bytes());
-    let hash: String = hasher
+    let hash = hasher
         .finalize()
         .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect();
+        .fold(String::new(), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        });
     hash[..16].to_string()
 }
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -388,7 +388,11 @@ impl CheckpointManager {
 pub fn compute_checksum(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Generate a stable pipeline ID from the pipeline structure.
@@ -396,7 +400,12 @@ pub fn compute_checksum(data: &[u8]) -> String {
 pub(crate) fn generate_pipeline_id(pipeline_hash: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(pipeline_hash.as_bytes());
-    format!("{:x}", hasher.finalize())[..16].to_string()
+    let hash: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    hash[..16].to_string()
 }
 
 /// Get current timestamp in milliseconds since epoch.

--- a/tests/helpers/distinct.rs
+++ b/tests/helpers/distinct.rs
@@ -17,9 +17,18 @@ fn distinct_by_removes_duplicates_by_field() -> Result<()> {
     let events = from_vec(
         &p,
         vec![
-            Event { user_id: 1, payload: "first".into() },
-            Event { user_id: 1, payload: "second".into() },
-            Event { user_id: 2, payload: "only".into() },
+            Event {
+                user_id: 1,
+                payload: "first".into(),
+            },
+            Event {
+                user_id: 1,
+                payload: "second".into(),
+            },
+            Event {
+                user_id: 2,
+                payload: "only".into(),
+            },
         ],
     );
     let mut result = events.distinct_by(|e| e.user_id).collect_seq()?;
@@ -43,7 +52,13 @@ fn distinct_by_empty_collection() -> Result<()> {
 #[test]
 fn distinct_by_single_element() -> Result<()> {
     let p = Pipeline::default();
-    let events = from_vec(&p, vec![Event { user_id: 42, payload: "hello".into() }]);
+    let events = from_vec(
+        &p,
+        vec![Event {
+            user_id: 42,
+            payload: "hello".into(),
+        }],
+    );
     let result = events.distinct_by(|e| e.user_id).collect_seq()?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].user_id, 42);
@@ -56,9 +71,18 @@ fn distinct_by_all_same_key_returns_one() -> Result<()> {
     let events = from_vec(
         &p,
         vec![
-            Event { user_id: 7, payload: "a".into() },
-            Event { user_id: 7, payload: "b".into() },
-            Event { user_id: 7, payload: "c".into() },
+            Event {
+                user_id: 7,
+                payload: "a".into(),
+            },
+            Event {
+                user_id: 7,
+                payload: "b".into(),
+            },
+            Event {
+                user_id: 7,
+                payload: "c".into(),
+            },
         ],
     );
     let result = events.distinct_by(|e| e.user_id).collect_seq()?;
@@ -73,9 +97,18 @@ fn distinct_by_all_unique_keys_passes_all_through() -> Result<()> {
     let events = from_vec(
         &p,
         vec![
-            Event { user_id: 1, payload: "a".into() },
-            Event { user_id: 2, payload: "b".into() },
-            Event { user_id: 3, payload: "c".into() },
+            Event {
+                user_id: 1,
+                payload: "a".into(),
+            },
+            Event {
+                user_id: 2,
+                payload: "b".into(),
+            },
+            Event {
+                user_id: 3,
+                payload: "c".into(),
+            },
         ],
     );
     let mut result = events.distinct_by(|e| e.user_id).collect_seq()?;
@@ -91,7 +124,10 @@ fn distinct_by_all_unique_keys_passes_all_through() -> Result<()> {
 fn distinct_by_string_key_projection() -> Result<()> {
     let p = Pipeline::default();
     // Deduplicate by first character of a string
-    let words = from_vec(&p, vec!["apple", "avocado", "banana", "blueberry", "cherry"]);
+    let words = from_vec(
+        &p,
+        vec!["apple", "avocado", "banana", "blueberry", "cherry"],
+    );
     let result_count = words
         .distinct_by(|w: &&str| w.chars().next().unwrap())
         .collect_seq()?
@@ -117,7 +153,10 @@ fn distinct_by_large_collection() -> Result<()> {
     let p = Pipeline::default();
     // 1000 elements, 10 distinct keys (0..10 cycling)
     let data: Vec<u32> = (0..1000).collect();
-    let result_count = from_vec(&p, data).distinct_by(|n| n % 10).collect_seq()?.len();
+    let result_count = from_vec(&p, data)
+        .distinct_by(|n| n % 10)
+        .collect_seq()?
+        .len();
     assert_eq!(result_count, 10);
     Ok(())
 }
@@ -128,8 +167,14 @@ fn distinct_by_retains_full_element_not_just_key() -> Result<()> {
     let events = from_vec(
         &p,
         vec![
-            Event { user_id: 5, payload: "payload_a".into() },
-            Event { user_id: 5, payload: "payload_b".into() },
+            Event {
+                user_id: 5,
+                payload: "payload_a".into(),
+            },
+            Event {
+                user_id: 5,
+                payload: "payload_b".into(),
+            },
         ],
     );
     let result = events.distinct_by(|e| e.user_id).collect_seq()?;


### PR DESCRIPTION
## Summary

- Upgrades `sha2` from `0.10` to `0.11` (and transitively `digest` `0.10` → `0.11`, `generic-array` → `hybrid-array`)
- Fixes broken hex formatting in `compute_checksum` and `generate_pipeline_id`: `digest` 0.11 replaced `generic-array` (which implemented `LowerHex`) with `hybrid-array` (which does not)
- Replaces `.map(|b| format!(...)).collect()` with `fold + write!` to satisfy `clippy::format_collect`

## Test plan

- [x] `cargo build --features checkpointing` — clean
- [x] `cargo test` — all 28 test suites pass (0 failures)
- [x] `cargo clippy -- -D warnings -W clippy::pedantic -W clippy::nursery` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)