### PR TITLE
feat(helpers): Reify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -132,7 +132,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
 dependencies = [
  "bytes",
  "half",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+checksum = "86c276756867fc8186ec380c72c290e6e3b23a1d4fb05df6b1d62d2e62666d48"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -215,15 +215,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+checksum = "f4518c59acc501f10d7dcae397fe12b8db3d81bc7de94456f8a58f9165d6f502"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -239,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -252,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -265,15 +266,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -285,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -346,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -463,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -481,9 +482,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -672,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -717,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -746,6 +747,36 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -777,8 +808,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -811,9 +855,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -843,9 +896,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -875,6 +928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,12 +941,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -927,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -943,13 +1004,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -1010,15 +1079,15 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1049,9 +1118,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -1171,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ordered-float"
@@ -1195,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+checksum = "43d7efd3052f7d6ef601085559a246bc991e9a8cc77e02753737df6322ce35f1"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1212,7 +1281,7 @@ dependencies = [
  "chrono",
  "flate2",
  "half",
- "hashbrown",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -1233,10 +1302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
+name = "pin-project-lite"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "postcard"
@@ -1321,9 +1396,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -1331,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1343,6 +1418,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1375,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1424,9 +1505,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"
@@ -1470,9 +1551,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -1492,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2784e59a0315568e850cb01ddadf458f8c09e28d8cfc4880c2cc08f5dc3444e0"
+checksum = "26e4ac1bef72720318e2c67bd19b972d17084840f3188a585021828122c43c2c"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -1556,7 +1637,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1567,15 +1648,21 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "snap"
@@ -1650,7 +1737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1721,15 +1808,21 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
@@ -1756,18 +1849,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1778,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1788,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1801,11 +1903,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1890,6 +2026,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xz2"
@@ -1902,18 +2126,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1922,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/FEATURE_PARITY_PLAN.md
+++ b/FEATURE_PARITY_PLAN.md
@@ -45,52 +45,13 @@ in Ironbeam. Features are organized by priority tier.
 | 2.5b Windowed Combine | `combine/sum/count/min/max/average_per_window` + `_per_key_and_window` helpers                                          | next        |
 | 2.6 Avro I/O          | `read_avro`/`write_avro` helpers with glob support; `AvroReader`/`AvroWriter` behind `io-avro` feature                  | 2.10.0      |
 | 2.7 XML I/O           | `read_xml`/`write_xml`/`read_xml_streaming`/`write_xml_par` with glob support; `XmlShards`/`XmlVecOps` behind `io-xml`  | 2.11.0      |
+| 3.1 Reshuffle         | Graph-level barrier; prevents fusion and redistributes elements across the pipeline graph                               | next        |
 | 3.2 WithTimestamps    | `attach_timestamps()` / `Timestamped<T>`                                                                                | 1.0.0       |
+| 3.3 Reify             | `reify_timestamps()` — project `Timestamped<T>` into `(TimestampMs, T)` tuples; inverse of `to_timestamped`             | next        |
 
 ---
 
 ## Tier 3: Nice-to-Have Features
-
-### 3.1 Reshuffle
-
-**Status:** Not implemented.
-
-Forces a barrier that prevents operation fusion and redistributes elements. In a local-only
-framework this is primarily useful for forcing checkpointing between stages or breaking
-processing skew.
-
-**Simple implementation:**
-```rust
-impl<T: RFBound> PCollection<T> {
-    pub fn reshuffle(self) -> PCollection<T> {
-        self.map(|elem| (rand::random::<u64>(), elem.clone()))
-            .group_by_key()
-            .flat_map(|(_, vs): &(u64, Vec<T>)| vs.clone())
-    }
-}
-```
-
-**Estimated complexity:** Low (simple form); Medium (true graph-level barrier)
-
----
-
-### 3.3 Reify
-
-**Status:** Not implemented. Primarily a debugging aid for windowed pipelines.
-
-Makes implicit metadata (timestamps) explicit in the data stream:
-
-```rust
-impl<T: RFBound> PCollection<Timestamped<T>> {
-    pub fn reify_timestamps(self) -> PCollection<(i64, T)> {
-        self.map(|ts: &Timestamped<T>| (ts.timestamp, ts.value.clone()))
-    }
-}
-```
-
-**Estimated complexity:** Low
-
----
 
 ### 3.4 PAssert Builder API
 
@@ -136,19 +97,3 @@ here for consideration before deciding whether to add them.
 | CBOR             | `ciborium`  | Compact binary; common in IoT                                      |
 | Arrow IPC        | `arrow`     | Already a dependency; efficient in-memory columnar exchange        |
 | Protocol Buffers | `prost`     | Widely used; Serde support is partial and may need custom handling |
-
----
-
-## Implementation Priority Order
-
-1. **Active (next):**
-   1. ~~2.4 — `filter_with_side_map`, `side_singleton`, `side_multimap`~~ ✅ complete
-   2. ~~2.5 — Regex transforms~~ ✅ complete
-   3. ~~2.5b — Windowed combining helpers~~ ✅ complete
-2. **Medium-term:**
-   1. ~~2.6 — Avro I/O~~ ✅ complete
-   2. ~~2.7 — XML I/O~~ ✅ complete
-3. **Polish:**
-   1. 3.1 — Reshuffle
-   2. 3.3 — Reify
-   3. 3.4 — PAssert builder API

--- a/src/helpers/timestamped.rs
+++ b/src/helpers/timestamped.rs
@@ -1,17 +1,20 @@
 //! Event-time helpers: attaching timestamps and normalizing timestamped inputs.
 //!
 //! This module provides lightweight utilities for working in **event time**.
-//! It lets you attach a millisecond timestamp to each element or normalize an
+//! It lets you attach a millisecond timestamp to each element, normalize an
 //! existing `(timestamp, value)` stream into the internal [`Timestamped<T>`]
-//! representation used by windowing transforms.
+//! representation used by windowing transforms, or project timestamps back out
+//! into the data stream as explicit tuple fields.
 //!
 //! ## Available operations
 //! - [`PCollection::attach_timestamps`](PCollection::attach_timestamps) - Attach event timestamps using a function
-//! - [`PCollection::to_timestamped`](crate::PCollection::to_timestamped) - Normalize `(timestamp, value)` pairs
+//! - [`PCollection::to_timestamped`](crate::PCollection::to_timestamped) - Normalize `(timestamp, value)` pairs into `Timestamped<T>`
+//! - [`PCollection::reify_timestamps`](crate::PCollection::reify_timestamps) - Make timestamps explicit as `(TimestampMs, T)` tuples
 //!
 //! ### What this is (and isn't)
 //! - ✅ Attaches/normalizes event timestamps, preserving data and order within a partition
 //! - ✅ Plays nicely with tumbling window helpers (e.g., `key_by_window(...)`)
+//! - ✅ Reifies timestamps as explicit data fields (inverse of `to_timestamped`)
 //! - ❌ Not a full watermark/late data engine -- timestamps are metadata used by
 //!   later operators; there's no lateness tracking or triggers.
 //!
@@ -36,6 +39,10 @@
 //! // From (ts, value) pairs: normalize to Timestamped<T>
 //! let pairs = from_vec(&p, vec![ (1000_u64, "x".to_string()), (1250_u64, "y".to_string()) ]);
 //! let stamped2 = pairs.to_timestamped();
+//!
+//! // Reify timestamps back out as explicit tuple fields
+//! let tuples = stamped2.reify_timestamps();
+//! // tuples: PCollection<(TimestampMs, String)>
 //! ```
 
 use crate::{PCollection, RFBound, TimestampMs, Timestamped};
@@ -103,5 +110,41 @@ impl<T: RFBound> PCollection<(TimestampMs, T)> {
     #[must_use]
     pub fn to_timestamped(self) -> PCollection<Timestamped<T>> {
         self.map(|p| Timestamped::new(p.0, p.1.clone()))
+    }
+}
+
+impl<T: RFBound> PCollection<Timestamped<T>> {
+    /// Make event-time timestamps explicit in the data stream.
+    ///
+    /// Projects each [`Timestamped<T>`] element into a `(timestamp_ms, value)` tuple,
+    /// dropping the wrapper type. This is the inverse of
+    /// [`PCollection::to_timestamped`].
+    ///
+    /// Primarily useful as a debugging aid: it lets you inspect timestamps as
+    /// ordinary data without needing to reach inside the [`Timestamped`] wrapper
+    /// downstream.
+    ///
+    /// ### Returns
+    /// A `PCollection<(TimestampMs, T)>` containing one tuple per input element,
+    /// where the first field is the event-time timestamp in milliseconds and the
+    /// second is the original value.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// use ironbeam::*;
+    /// use ironbeam::window::Timestamped;
+    ///
+    /// let p = Pipeline::default();
+    /// let events = from_vec(&p, vec![
+    ///     Timestamped::new(1_000u64, "hello".to_string()),
+    ///     Timestamped::new(2_000u64, "world".to_string()),
+    /// ]);
+    ///
+    /// let tuples = events.reify_timestamps();
+    /// // tuples: PCollection<(TimestampMs, String)>
+    /// ```
+    #[must_use]
+    pub fn reify_timestamps(self) -> PCollection<(TimestampMs, T)> {
+        self.map(|ts: &Timestamped<T>| (ts.ts, ts.value.clone()))
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -6,6 +6,7 @@ mod distinct;
 mod joins;
 mod parquet;
 mod regex;
+mod reify;
 mod reshuffle;
 mod side_input;
 mod statistical;

--- a/tests/helpers/reify.rs
+++ b/tests/helpers/reify.rs
@@ -1,0 +1,252 @@
+//! Tests for [`PCollection::reify_timestamps`].
+
+use anyhow::Result;
+use ironbeam::window::Timestamped;
+use ironbeam::*;
+
+// --- Basic correctness -------------------------------------------------------
+
+#[test]
+fn reify_empty_collection() -> Result<()> {
+    let p = Pipeline::default();
+    let result = from_vec::<Timestamped<u32>>(&p, vec![])
+        .reify_timestamps()
+        .collect_seq()?;
+    assert!(result.is_empty());
+    Ok(())
+}
+
+#[test]
+fn reify_single_element_timestamp() -> Result<()> {
+    let p = Pipeline::default();
+    let result = from_vec(&p, vec![Timestamped::new(42u64, 99u32)])
+        .reify_timestamps()
+        .collect_seq()?;
+    assert_eq!(result, vec![(42u64, 99u32)]);
+    Ok(())
+}
+
+#[test]
+fn reify_preserves_timestamp_value() -> Result<()> {
+    let p = Pipeline::default();
+    let result = from_vec(
+        &p,
+        vec![Timestamped::new(
+            1_700_000_000_000u64,
+            "payload".to_string(),
+        )],
+    )
+    .reify_timestamps()
+    .collect_seq()?;
+    assert_eq!(result[0].0, 1_700_000_000_000u64);
+    Ok(())
+}
+
+#[test]
+fn reify_preserves_element_value() -> Result<()> {
+    let p = Pipeline::default();
+    let result = from_vec(&p, vec![Timestamped::new(1u64, "hello".to_string())])
+        .reify_timestamps()
+        .collect_seq()?;
+    assert_eq!(result[0].1, "hello");
+    Ok(())
+}
+
+// --- Multiple elements -------------------------------------------------------
+
+#[test]
+fn reify_multiple_elements_all_preserved() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(100u64, 1u32),
+        Timestamped::new(200u64, 2u32),
+        Timestamped::new(300u64, 3u32),
+    ];
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(result, vec![(100u64, 1u32), (200u64, 2u32), (300u64, 3u32)]);
+    Ok(())
+}
+
+#[test]
+#[allow(clippy::cast_possible_truncation)]
+fn reify_distinct_timestamps_preserved() -> Result<()> {
+    let p = Pipeline::default();
+    let input: Vec<Timestamped<u32>> = (1u64..=5)
+        .map(|ts| Timestamped::new(ts * 1000, ts as u32))
+        .collect();
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    let expected: Vec<(u64, u32)> = (1u64..=5).map(|ts| (ts * 1000, ts as u32)).collect();
+    assert_eq!(result, expected);
+    Ok(())
+}
+
+#[test]
+fn reify_duplicate_timestamps_all_emitted() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(999u64, 10u32),
+        Timestamped::new(999u64, 20u32),
+        Timestamped::new(999u64, 30u32),
+    ];
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|&(_, v)| v);
+    assert_eq!(
+        result,
+        vec![(999u64, 10u32), (999u64, 20u32), (999u64, 30u32)]
+    );
+    Ok(())
+}
+
+// --- Element types -----------------------------------------------------------
+
+#[test]
+fn reify_string_values() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(1u64, "alpha".to_string()),
+        Timestamped::new(2u64, "beta".to_string()),
+    ];
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|(_, v)| v.clone());
+    assert_eq!(
+        result,
+        vec![(1u64, "alpha".to_string()), (2u64, "beta".to_string())]
+    );
+    Ok(())
+}
+
+#[test]
+fn reify_struct_values() -> Result<()> {
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(10u64, Point { x: 1, y: 2 }),
+        Timestamped::new(20u64, Point { x: 3, y: 4 }),
+    ];
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|(ts, _)| *ts);
+    assert_eq!(
+        result,
+        vec![(10u64, Point { x: 1, y: 2 }), (20u64, Point { x: 3, y: 4 })]
+    );
+    Ok(())
+}
+
+#[test]
+fn reify_tuple_values() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(5u64, (1u32, "a".to_string())),
+        Timestamped::new(10u64, (2u32, "b".to_string())),
+    ];
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(
+        result,
+        vec![
+            (5u64, (1u32, "a".to_string())),
+            (10u64, (2u32, "b".to_string())),
+        ]
+    );
+    Ok(())
+}
+
+// --- Round-trip / inverse ----------------------------------------------------
+
+#[test]
+fn reify_is_inverse_of_to_timestamped() -> Result<()> {
+    let p = Pipeline::default();
+    let pairs = vec![(100u64, 1u32), (200u64, 2u32), (300u64, 3u32)];
+    let mut result = from_vec(&p, pairs.clone())
+        .to_timestamped()
+        .reify_timestamps()
+        .collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(result, pairs);
+    Ok(())
+}
+
+#[test]
+fn to_timestamped_is_inverse_of_reify() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(50u64, "x".to_string()),
+        Timestamped::new(75u64, "y".to_string()),
+    ];
+    let mut result = from_vec(&p, input.clone())
+        .reify_timestamps()
+        .to_timestamped()
+        .collect_seq()?;
+    result.sort_unstable_by_key(|ts| ts.ts);
+    assert_eq!(result, input);
+    Ok(())
+}
+
+// --- Composition -------------------------------------------------------------
+
+#[test]
+fn reify_chainable_with_map() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![Timestamped::new(1u64, 10u32), Timestamped::new(2u64, 20u32)];
+    let mut result = from_vec(&p, input)
+        .reify_timestamps()
+        .map(|(ts, v): &(u64, u32)| (*ts, v * 2))
+        .collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(result, vec![(1u64, 20u32), (2u64, 40u32)]);
+    Ok(())
+}
+
+#[test]
+fn reify_after_attach_timestamps() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![1u32, 2, 3];
+    let mut result = from_vec(&p, input)
+        .attach_timestamps(|&v| u64::from(v) * 100)
+        .reify_timestamps()
+        .collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(result, vec![(100u64, 1u32), (200u64, 2u32), (300u64, 3u32)]);
+    Ok(())
+}
+
+#[test]
+fn reify_chainable_with_filter() -> Result<()> {
+    let p = Pipeline::default();
+    let input = vec![
+        Timestamped::new(1u64, 1u32),
+        Timestamped::new(2u64, 2u32),
+        Timestamped::new(3u64, 3u32),
+        Timestamped::new(4u64, 4u32),
+    ];
+    let mut result = from_vec(&p, input)
+        .reify_timestamps()
+        .filter(|(_, v): &(u64, u32)| v % 2 == 0)
+        .collect_seq()?;
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    assert_eq!(result, vec![(2u64, 2u32), (4u64, 4u32)]);
+    Ok(())
+}
+
+// --- Scalability -------------------------------------------------------------
+
+#[test]
+#[allow(clippy::cast_possible_truncation)]
+fn reify_large_collection() -> Result<()> {
+    let p = Pipeline::default();
+    let n = 1_000u64;
+    let input: Vec<Timestamped<u64>> = (0..n).map(|i| Timestamped::new(i * 10, i)).collect();
+    let mut result = from_vec(&p, input).reify_timestamps().collect_seq()?;
+    assert_eq!(result.len(), n as usize);
+    result.sort_unstable_by_key(|&(ts, _)| ts);
+    let expected: Vec<(u64, u64)> = (0..n).map(|i| (i * 10, i)).collect();
+    assert_eq!(result, expected);
+    Ok(())
+}


### PR DESCRIPTION
Projects each Timestamped<T> into a (TimestampMs, T) tuple, making event-time metadata explicit as ordinary data. Inverse of to_timestamped. Includes 16 tests covering correctness, element types, round-trip invariants, composition, and scalability.